### PR TITLE
feat: swap to negativo17 as nvidia driver source

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -40,9 +40,9 @@ jobs:
           - lazurite
           - mate
           - vauxite
-        nvidia_version:
-          - 0   # No Nvidia drivers (this indicates to only build "main" image target
-          - 550 # Latest Nvidia driver (update IS_LATEST_DRIVER below if version changes)
+        image_target:
+          - main
+          - nvidia
         exclude:
           # There is no Fedora 38 version of onyx or lazurite
           - image_name: onyx
@@ -58,8 +58,8 @@ jobs:
           - image_name: mate
             fedora_version: 40
           # Don't build/push "main" since it would be a duplicate of the "base" `*-main` images
-          - nvidia_version: 0
-            hwe_flavor: main
+          - hwe_flavor: main
+            image_target: main
           # Only build latest Fedora versions for "asus" and "surface" HWE flavors
           - fedora_version: 38
             hwe_flavor: asus
@@ -79,13 +79,13 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ matrix.hwe_flavor }}" == "main" ]]; then
-            if [[ "${{ matrix.nvidia_version }}" == "0" ]]; then
+            if [[ "${{ matrix.image_target }}" == "main" ]]; then
               echo "this workflow does not build main image without Nvidia drivers"
               exit 1
             fi
             echo "IMAGE_NAME=${{ matrix.image_name }}-nvidia" >> $GITHUB_ENV
           else
-            if [[ "${{ matrix.nvidia_version }}" == "0" ]]; then
+            if [[ "${{ matrix.image_target }}" == "main" ]]; then
               echo "IMAGE_NAME=${{ matrix.image_name }}-${{ matrix.hwe_flavor }}" >> $GITHUB_ENV
             else
               echo "IMAGE_NAME=${{ matrix.image_name }}-${{ matrix.hwe_flavor }}-nvidia" >> $GITHUB_ENV
@@ -99,11 +99,7 @@ jobs:
         run: |
           # Generate a timestamp for creating an image version history
           TIMESTAMP="$(date +%Y%m%d)"
-          if [[ "${{ matrix.nvidia_version }}" == "0" ]]; then
-            VARIANT="${{ matrix.fedora_version }}"
-          else
-            VARIANT="${{ matrix.fedora_version }}-${{ matrix.nvidia_version }}"
-          fi
+          VARIANT="${{ matrix.fedora_version }}"
 
           if [[ "${{ matrix.fedora_version }}" -eq "38" ]]; then
             IS_LATEST_VERSION=false
@@ -119,10 +115,6 @@ jobs:
             IS_GTS_VERSION=false
           fi
 
-          if [[ "${{ matrix.nvidia_version }}" -eq "550" ]]; then
-            IS_LATEST_DRIVER=true
-          fi
-
           COMMIT_TAGS=()
           BUILD_TAGS=()
 
@@ -132,18 +124,12 @@ jobs:
           COMMIT_TAGS+=("${SHA_SHORT}-${VARIANT}")
 
           if [[ "${IS_LATEST_VERSION}" == "true" ]] && \
-             [[ "${IS_STABLE_VERSION}" == "true" ]] && \
-             [[ "${IS_LATEST_DRIVER}" == "true" ]]; then
+             [[ "${IS_STABLE_VERSION}" == "true" ]]; then
               COMMIT_TAGS+=("pr-${{ github.event.number }}")
               COMMIT_TAGS+=("${SHA_SHORT}")
           fi
 
           BUILD_TAGS=("${VARIANT}")
-
-          if [[ "${IS_LATEST_DRIVER}" == "true" ]]; then
-              BUILD_TAGS+=("${{ matrix.fedora_version }}-current")
-              BUILD_TAGS+=("${{ matrix.fedora_version }}")
-          fi
 
           # Append matching timestamp tags to keep a version history
           for TAG in "${BUILD_TAGS[@]}"; do
@@ -151,14 +137,13 @@ jobs:
           done
 
           if [[ "${IS_LATEST_VERSION}" == "true" ]] && \
-             [[ "${IS_STABLE_VERSION}" == "true" ]] && \
-             [[ "${IS_LATEST_DRIVER}" == "true" ]]; then
+             [[ "${IS_STABLE_VERSION}" == "true" ]]; then
               BUILD_TAGS+=("${TIMESTAMP}")
               BUILD_TAGS+=("latest")
           fi
 
           if [[ "${IS_GTS_VERSION}" == "true" ]] && \
-             [[ "${IS_LATEST_DRIVER}" == "true" ]]; then
+             [[ "${IS_STABLE_VERSION}" == "true" ]]; then
               BUILD_TAGS+=("gts-${TIMESTAMP}")
               BUILD_TAGS+=("gts")
           fi
@@ -205,7 +190,7 @@ jobs:
             ${{ env.IMAGE_NAME }}
           labels: |
             org.opencontainers.image.title=${{ env.IMAGE_NAME }}
-            org.opencontainers.image.description=ublue-os ${{ matrix.image_name }}${{ matrix.hwe_flavor == 'asus' && ' for ASUS devices' || '' }}${{ matrix.hwe_flavor == 'surface' && ' for Surface laptops' || ''}}${{ matrix.nvidia_version != '0' && ' with Nvidia drivers' || ''}}
+            org.opencontainers.image.description=ublue-os ${{ matrix.image_name }}${{ matrix.hwe_flavor == 'asus' && ' for ASUS devices' || '' }}${{ matrix.hwe_flavor == 'surface' && ' for Surface laptops' || ''}}${{ matrix.image_target == 'nvidia' && ' with Nvidia drivers' || ''}}
             org.opencontainers.image.version=${{ env.SOURCE_IMAGE_VERSION }}
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/${{ github.repository }}/main/README.md
             io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/1728152?s=200&v=4
@@ -234,13 +219,12 @@ jobs:
             IMAGE_NAME=${{ matrix.image_name }}
             SOURCE_IMAGE=${{ env.SOURCE_IMAGE }}
             FEDORA_MAJOR_VERSION=${{ matrix.fedora_version }}
-            NVIDIA_MAJOR_VERSION=${{ matrix.nvidia_version }}
             HWE_FLAVOR=${{ matrix.hwe_flavor }}
             RPMFUSION_MIRROR=${{ vars.RPMFUSION_MIRROR }}
           labels: ${{ steps.meta.outputs.labels }}
           oci: false
           extra-args: |
-            --target=${{ matrix.nvidia_version == '0' && 'main' || 'nvidia' }}
+            --target=${{ matrix.image_target }}
 
       # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
       # https://github.com/macbre/push-to-ghcr/issues/12

--- a/Containerfile
+++ b/Containerfile
@@ -31,10 +31,9 @@ ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-39}"
 ARG HWE_FLAVOR="{HWE_FLAVOR:-main}"
 ARG IMAGE_NAME="${IMAGE_NAME:-silverblue}"
 ARG IMAGE_VENDOR="${IMAGE_VENDOR:-ublue-os}"
-ARG NVIDIA_MAJOR_VERSION="${NVIDIA_MAJOR_VERSION:-550}"
 ARG RPMFUSION_MIRROR=""
 
-COPY --from=ghcr.io/ublue-os/akmods-nvidia:${HWE_FLAVOR}-${FEDORA_MAJOR_VERSION}-${NVIDIA_MAJOR_VERSION} /rpms /tmp/akmods-rpms
+COPY --from=ghcr.io/ublue-os/akmods-nvidia:${HWE_FLAVOR}-${FEDORA_MAJOR_VERSION} /rpms /tmp/akmods-rpms
 
 COPY *.sh /tmp/
 

--- a/nvidia-install.sh
+++ b/nvidia-install.sh
@@ -44,6 +44,9 @@ else
 fi
 
 rpm-ostree install \
+    libva-nvidia-driver \
+    mesa-vulkan-drivers.i686 \
+    nvidia-driver \
     nvidia-driver \
     nvidia-driver-cuda \
     nvidia-driver-cuda-libs.i686 \

--- a/nvidia-install.sh
+++ b/nvidia-install.sh
@@ -25,10 +25,15 @@ if [ -n "${RPMFUSION_MIRROR}" ]; then
 fi
 
 
-# nvidia install steps
+## nvidia install steps
 rpm-ostree install /tmp/akmods-rpms/ublue-os/ublue-os-nvidia-addons-*.rpm
 
-source /tmp/akmods-rpms/kmods/nvidia-vars.${NVIDIA_MAJOR_VERSION}
+# enables nvidia repos provided by ublue-os-nvidia-addons
+sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' /etc/yum.repos.d/eyecantcu-supergfxctl.repo
+sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' /etc/yum.repos.d/negativo17-fedora-nvidia.repo
+sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' /etc/yum.repos.d/nvidia-container-toolkit.repo
+
+source /tmp/akmods-rpms/kmods/nvidia-vars
 
 if [[ "${IMAGE_NAME}" == "kinoite" ]]; then
     VARIANT_PKGS="supergfxctl-plasmoid supergfxctl"
@@ -39,14 +44,22 @@ else
 fi
 
 rpm-ostree install \
-    xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-{,cuda-,devel-,kmodsrc-,power-}${NVIDIA_FULL_VERSION} \
-    xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-libs.i686 \
-    nvidia-container-toolkit nvidia-vaapi-driver ${VARIANT_PKGS} \
-    /tmp/akmods-rpms/kmods/kmod-${NVIDIA_PACKAGE_NAME}-${KERNEL_VERSION}-${NVIDIA_AKMOD_VERSION}.fc${RELEASE}.rpm
+    nvidia-driver \
+    nvidia-driver-cuda \
+    nvidia-driver-cuda-libs.i686 \
+    nvidia-driver-libs.i686 \
+    nvidia-driver-NVML.i686 \
+    nvidia-driver-NvFBCOpenGL \
+    nvidia-modprobe \
+    nvidia-persistenced \
+    nvidia-settings \
+    nvidia-container-toolkit ${VARIANT_PKGS} \
+    /tmp/akmods-rpms/kmods/kmod-nvidia-${KERNEL_VERSION}-${NVIDIA_AKMOD_VERSION}.fc${RELEASE}.rpm
 
 
-# nvidia post-install steps
-sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/{eyecantcu-supergfxctl,nvidia-container-toolkit}.repo
+## nvidia post-install steps
+# disables nvidia repos provided by ublue-os-nvidia-addons
+sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/{eyecantcu-supergfxctl,negativo17-fedora-nvidia,nvidia-container-toolkit}.repo
 
 systemctl enable ublue-nvctk-cdi.service
 semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp

--- a/nvidia-install.sh
+++ b/nvidia-install.sh
@@ -25,10 +25,15 @@ if [ -n "${RPMFUSION_MIRROR}" ]; then
 fi
 
 
-# nvidia install steps
+## nvidia install steps
 rpm-ostree install /tmp/akmods-rpms/ublue-os/ublue-os-nvidia-addons-*.rpm
 
-source /tmp/akmods-rpms/kmods/nvidia-vars.${NVIDIA_MAJOR_VERSION}
+# enables nvidia repos provided by ublue-os-nvidia-addons
+sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' /etc/yum.repos.d/eyecantcu-supergfxctl.repo
+sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' /etc/yum.repos.d/negativo17-fedora-nvidia.repo
+sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' /etc/yum.repos.d/nvidia-container-toolkit.repo
+
+source /tmp/akmods-rpms/kmods/nvidia-vars
 
 if [[ "${IMAGE_NAME}" == "kinoite" ]]; then
     VARIANT_PKGS="supergfxctl-plasmoid supergfxctl"
@@ -54,8 +59,9 @@ rpm-ostree install \
     /tmp/akmods-rpms/kmods/kmod-nvidia-${KERNEL_VERSION}-${NVIDIA_AKMOD_VERSION}.fc${RELEASE}.rpm
 
 
-# nvidia post-install steps
-sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/{eyecantcu-supergfxctl,nvidia-container-toolkit}.repo
+## nvidia post-install steps
+# disables nvidia repos provided by ublue-os-nvidia-addons
+sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/{eyecantcu-supergfxctl,negativo17-fedora-nvidia,nvidia-container-toolkit}.repo
 
 systemctl enable ublue-nvctk-cdi.service
 semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp


### PR DESCRIPTION
This reworks all the bits in akmods for nvidia:

    removes nvidia driver version as only latest is supported
    uses negativo17 nvidia driver and packages
    maintains expected packages

This is a second attempt since the first was reverted: (see https://github.com/ublue-os/hwe/pull/233)